### PR TITLE
Get solc releases directly from solidity repo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 buildscript {
     ext.kotlin_version = '1.3.61'
+    ext.jacksonVersion = '2.12.7'
     repositories { jcenter() }
 
     dependencies {
@@ -57,7 +58,10 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
             "org.apache.commons:commons-lang3:3.0",
             "com.github.zafarkhaja:java-semver:0.9.0",
-            "org.jetbrains.kotlinx:kotlinx-serialization-runtime:0.14.0"
+            "org.jetbrains.kotlinx:kotlinx-serialization-runtime:0.14.0",
+            "com.fasterxml.jackson.core:jackson-core:$jacksonVersion",
+            "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion",
+            "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
     testImplementation "org.junit.jupiter:junit-jupiter-engine:$junitVersion",
             "org.junit.jupiter:junit-jupiter-api:$junitVersion",
             "org.junit.jupiter:junit-jupiter-params:$junitVersion"

--- a/src/main/kotlin/org/web3j/sokt/SolcReleaseInfo.kt
+++ b/src/main/kotlin/org/web3j/sokt/SolcReleaseInfo.kt
@@ -1,0 +1,29 @@
+package org.web3j.sokt
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonProperty
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class SolcReleaseAsset (
+    @JsonProperty("browser_download_url")
+    var browserDownloadUrl: String
+)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class SolcReleaseInfo(
+    @JsonProperty("tag_name")
+    var tagName: String,
+    var assets: List<SolcReleaseAsset>
+) {
+    fun toSolcRelease(): SolcRelease {
+        val macUrl: String = assets.find { asset -> asset.browserDownloadUrl.contains("macos") }?.browserDownloadUrl ?: ""
+        val linuxUrl: String = assets.find { asset -> asset.browserDownloadUrl.contains("linux") }?.browserDownloadUrl ?: ""
+        val windowsUrl: String = assets.find { asset -> asset.browserDownloadUrl.contains("windows") }?.browserDownloadUrl ?: ""
+        return SolcRelease(
+            version = tagName.removePrefix("v"),
+            windowsUrl = windowsUrl,
+            linuxUrl = linuxUrl,
+            macUrl = macUrl
+        )
+    }
+}


### PR DESCRIPTION
Retrieve the list of releases and download urls directly from the solidity repo instead of from the web3j-sokt maintained json-file.